### PR TITLE
Fix link to images in OS-intro

### DIFF
--- a/intro-open-science/index.html
+++ b/intro-open-science/index.html
@@ -51,13 +51,17 @@
 					</script>
 				</section>
 
-				
+
 				<section>
 					<section data-markdown>
 						<script type="text/template">
 							## What are the benefits of Open Research?
 							* Establish trust in your research
-							![](presentations/intro-open-science/benefits-of-oa-new.jpg)
+						</script>
+					</section>
+					<section data-markdown>
+						<script type="text/template">
+							![](benefits-of-oa-new.jpg)
 						</script>
 					</section>
 				</section>
@@ -86,7 +90,7 @@
 						</script>
 					</section>
 				</section>
-				
+
 			</div>
 		</div>
 


### PR DESCRIPTION
Since you were linking to an image in the same directory as your `index.html` file, you don't have to specify directories in the URL; just the name of the file will do (see in this commit).

Also, the image is pretty huge and if you want to use vanilla markdown, it's not possible (as far as I know) to control the image's display size. So, I simply moved it to a new slide. Hope this works!
